### PR TITLE
Typo

### DIFF
--- a/template.json
+++ b/template.json
@@ -121,7 +121,7 @@
             "templates": ["common"]
         },
         "weapon": {
-            "templates": ["common", "range", "weight"],
+            "templates": ["common", "ranged", "weight"],
             "damage": 0,
             "weaponType": "Bashing"
         }


### PR DESCRIPTION
There was no template named 'range' for weapon to call. It is called 'ranged'.