### PR TITLE
Fix for Focus and for rolling Numenera form

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -221,6 +221,8 @@
     "NUMENERA.item.armor.price": "Price",
     "NUMENERA.item.armor.description": "Description",
     "NUMENERA.item.armor.newArmor": "New Armor",
+	
+	"NUMENERA.item.numenera.formPlaceholder": "You can add many form by separating them with ','",
 
     "NUMENERA.item.artifact.level": "Level",
     "NUMENERA.item.artifact.form": "Form",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -222,6 +222,8 @@
     "NUMENERA.item.armor.price": "Prix",
     "NUMENERA.item.armor.description": "Description",
     "NUMENERA.item.armor.newArmor": "Nouvelle armure",
+	
+	"NUMENERA.item.numenera.formPlaceholder": "Vous pouvez ajouter plusieurs formes en les séparant par ','",
 
     "NUMENERA.item.artifact.level": "Niveau",
     "NUMENERA.item.artifact.form": "Forme",

--- a/module/actor/NumeneraPCActor.js
+++ b/module/actor/NumeneraPCActor.js
@@ -21,9 +21,10 @@ export class NumeneraPCActor extends Actor {
 
   getFocus() {
     //Add any game-specific logic to get the PC's focus here
+	var allFocus = this.data.data.focus;
 
     //Default case: there is no specific ID
-    return this.data.data.focus[""];
+    return allFocus[Object.keys(allFocus)[0]];
   }
 
   setFocusFromEvent(event) {
@@ -32,18 +33,13 @@ export class NumeneraPCActor extends Actor {
 
   setFocus(value) {
     //Add any game-specific logic to set a PC focus here
-
-    //TEMPORARY PATCH because of https://github.com/SolarBear/Numenera-FoundryVTT/issues/92
-    if (typeof this.data.data.focus === "string") {
-      const focus = this.data.data.focus;
-      this.data.data.focus = {};
-    }
+	var allFocus = this.data.data.focus;
 
     //Default case: there is no specific ID
-    this.data.data.focus[""] = value;
+    allFocus[Object.keys(allFocus)[0]] = value;
 
     const data = {_id: this._id};
-    data["data.focus['']"] = {"": value};
+    data["data.focus"] = {"": value};
 
     this.update(data);
   }
@@ -397,6 +393,16 @@ export class NumeneraPCActor extends Actor {
         } else {
           itemData.level = itemData.level || null;
         }
+		
+		// Get the form of the artifact/cypher
+		try {
+			let forms = itemData.form.split(',');
+			let form = forms[Math.floor(Math.random() * forms.length)];
+			
+			itemData.form = form;
+		} catch (Error) {
+			//Leave it as it is
+		}
         break;
     }
 

--- a/system.json
+++ b/system.json
@@ -1,7 +1,7 @@
 {
     "name": "numenera",
     "title": "Numenera",
-    "description": "Simple support for Numenera and The Strange for the Fountry Virtual TableTop.",
+    "description": "Unofficial port from the https://github.com/SolarBear/Numenera-FoundryVTT, as we wait for SolarBear. Simple support for Numenera and The Strange for the Fountry Virtual TableTop.",
     "version": "0.16.0",
     "author": "SolarBear",
     "scripts": ["lib/dragula/dragula.min.js"],
@@ -21,9 +21,9 @@
         }
     ],
     "socket": true,
-    "compatibleCoreVersion": "0.6.4",
+    "compatibleCoreVersion": "0.6.5",
     "minimumCoreVersion" : "0.5.5",
-    "url": "https://github.com/SolarBear/Numenera-FoundryVTT",
-    "manifest": "https://raw.githubusercontent.com/SolarBear/Numenera-FoundryVTT/master/system.json",
-    "download": "https://github.com/SolarBear/Numenera-FoundryVTT/releases/download/0.15.1/numenera-foundryvtt-0.16.0.zip"
+    "url": "https://github.com/NiceTSY/Numenera-FoundryVTT",
+    "manifest": "https://raw.githubusercontent.com/NiceTSY/Numenera-FoundryVTT/master/system.json",
+    "download": "https://github.com/NiceTSY/Numenera-FoundryVTT/releases/download/0.16.0/numenera-foundryvtt-0.16.0.zip"
 }

--- a/templates/item/artifactSheet.html
+++ b/templates/item/artifactSheet.html
@@ -10,7 +10,7 @@
             </label>
 
             <label>{{localize "NUMENERA.item.artifact.form"}}
-                <input type="text" id="data.form" name="data.form" value="{{data.form}}" data-dtype="String" />
+                <input type="text" id="data.form" name="data.form" value="{{data.form}}" placeholder="{{localize "NUMENERA.item.numenera.formPlaceholder"}}" data-dtype="String" />
             </label>
 
             <label for="data.depletion.isDepleting">{{localize "NUMENERA.item.artifact.depletion"}}

--- a/templates/item/cypherSheet.html
+++ b/templates/item/cypherSheet.html
@@ -22,7 +22,7 @@
             {{/if}}
 
             <label>{{localize "NUMENERA.item.cypher.form"}}
-                <input type="text" name="data.form" value="{{data.form}}" />
+                <input type="text" name="data.form" value="{{data.form}}" placeholder="{{localize "NUMENERA.item.numenera.formPlaceholder"}}" />
             </label>
         </div>
     </div>


### PR DESCRIPTION
**Focus fix:**
Updated the way of the code was trying to handle the load and save of the focus by implementing a correct key lookup for the Focus data object

**Rolling Numenera form**
A temporal way around to handle the form of a Numenera item (both artefacts and cyphers) by breaking potential form via ',' and randomly choosing one

**Added an unofficial 0.16 release in system.json** that will need to be changed when Solar kick back on it.