### PR TITLE
Weapon names turn to 'new item', armor similar

### DIFF
--- a/module/item/NumeneraArmorItem.js
+++ b/module/item/NumeneraArmorItem.js
@@ -14,15 +14,15 @@ export class NumeneraArmorItem extends Item {
 
     static fromOwnedItem(ownedItem, actor) {
         let armorItem = new NumeneraArmorItem();
-        armorItem.data._id = ownedItem._id;
-        armorItem.data.data = ownedItem.data.data || {};
-        armorItem.data.data.name = ownedItem.name;
-        armorItem.data.data.armor = ownedItem.data.armor;
-        armorItem.data.data.notes = ownedItem.data.notes;
-        armorItem.data.data.price = ownedItem.data.price;
-        armorItem.data.data.weight = ownedItem.data.weight;
-        armorItem.data.data.skillLevel = ownedItem.data.skillLevel;
-        armorItem.data.data.additionalSpeedEffortCost = ownedItem.data.additionalSpeedEffortCost;
+        armorItem._data._id = ownedItem._id;
+        armorItem._data.data = ownedItem.data.data || {};
+        armorItem._data.data.name = ownedItem.name;
+        armorItem._data.data.armor = ownedItem.data.armor;
+        armorItem._data.data.notes = ownedItem.data.notes;
+        armorItem._data.data.price = ownedItem.data.price;
+        armorItem._data.data.weight = ownedItem.data.weight;
+        armorItem._data.data.skillLevel = ownedItem.data.skillLevel;
+        armorItem._data.data.additionalSpeedEffortCost = ownedItem.data.additionalSpeedEffortCost;
         armorItem.options.actor = actor;
     
         armorItem.prepareData();

--- a/module/item/NumeneraSkillItem.js
+++ b/module/item/NumeneraSkillItem.js
@@ -12,7 +12,7 @@ export class NumeneraSkillItem extends Item {
 
     skillItem._data._id = ownedItem._id;
     skillItem._data.name = ownedItem.name;
-    skillItem._data.data = {};
+    skillItem._data.data = ownedItem.data.data || {};
     skillItem._data.data.notes = ownedItem.data.notes;
     skillItem._data.data.relatedAbilityId = ownedItem.data.relatedAbilityId;
     skillItem._data.data.stat = ownedItem.data.stat;

--- a/module/item/NumeneraWeaponItem.js
+++ b/module/item/NumeneraWeaponItem.js
@@ -62,7 +62,8 @@ export class NumeneraWeaponItem extends Item {
 
         if (!skill) {
             skill = new NumeneraSkillItem();
-            skill.data.name = `${game.i18n.localize(this.data.data.weight)} ${game.i18n.localize(this.data.data.weaponType)}`;
+            skill.data.data = skill.data.data || {};
+            skill.data.name = skill.data.data.name = skill._data.name = `${game.i18n.localize(this.data.data.weight)} ${game.i18n.localize(this.data.data.weaponType)}`;
             skill.options.actor = this.actor;
         }
         else if (skill.prototype !== NumeneraSkillItem) {


### PR DESCRIPTION
If you roll a weapon without an associated skill, a new skill is created but the name is shown as 'New item' in the roll dialog.

Armor also has the same issue with names being lost when copied, and I've accounted for the possibility that skills might already have a data.data instead of just creating a new object