### PR TITLE
Fix 'Other Enhancements' in EffortDialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -29,7 +29,7 @@
     "NUMENERA.effort.title": "Effort",
     "NUMENERA.effort.againstTaskLevel": "against task level",
     "NUMENERA.effort.failAutomatically": "Automatic Failure",
-    "NUMENERA.effort.other": "Other Enhancements",
+    "NUMENERA.effort.other": "Assets",
     "NUMENERA.effort.confirmUnspentTitle": "Confirm: Unspent Points",
     "NUMENERA.effort.confirmUnspent": "You have unspent points are your pools are not full yet. Do you really want to exit? These points will be lost.",
     "NUMENERA.effort.cost": "Cost",
@@ -111,7 +111,7 @@
 
     "NUMENERA.pcActorSheet.tab.skills": "Skills",
     "NUMENERA.pcActorSheet.tab.abilities": "Abilities",
-    "NUMENERA.pcActorSheet.tab.cyphers": "Cyphers",
+    "NUMENERA.pcActorSheet.tab.cyphers": "Numenera",
     "NUMENERA.pcActorSheet.tab.strange": "Strange",
     "NUMENERA.pcActorSheet.tab.recursion": "Recursions",
     "NUMENERA.pcActorSheet.tab.equipment": "Equipment",

--- a/module/actor/NumeneraPCActor.js
+++ b/module/actor/NumeneraPCActor.js
@@ -134,7 +134,7 @@ export class NumeneraPCActor extends Actor {
 
     rollData.ability = ability;
     rollData.enhancements = enhancements;
-    
+
     const roll = rollData.getRoll();
     roll.roll();
 
@@ -142,7 +142,7 @@ export class NumeneraPCActor extends Actor {
 
     const mods = []; //any roll modifier goes here: effort, skill level, etc.
 
-    switch (skill.data.data.skillLevel) {
+    switch (Number(skill.data.data.skillLevel)) {
       case 2:
         mods.push("specialized");
         break;
@@ -166,7 +166,7 @@ export class NumeneraPCActor extends Actor {
     roll.toMessage({
       speaker: ChatMessage.getSpeaker(),
       messageData: RollData.rollText(roll),
-      flavor,
+      flavor: flavor,
     },
     {
       rollMode: rollData.rollMode,
@@ -184,11 +184,12 @@ export class NumeneraPCActor extends Actor {
    * @memberof NumeneraPCActor
    */
   async rollAttribute(attribute, rollData = null) {
-    if (rollData === null && useAlternateButtonBehavior()) {      
+    if (rollData === null && useAlternateButtonBehavior()) {
       const dialog = new EffortDialog(this, { stat: attribute });
       await dialog.init();
       return dialog.render(true);
     }
+    //console.log(dialog);
 
     // Create a pseudo-skill to avoid repeating the roll logic
     //Do NOT create an embedded Document here, we really want a temporary item
@@ -199,7 +200,12 @@ export class NumeneraPCActor extends Actor {
     //Need to modify the deep property since skill.name is a getter
     skill.data.data.name = attribute.replace(/^\w/, (c) => c.toUpperCase()); //capitalized
 
-    return this.rollSkill(skill, rollData);
+    let assets = 0;
+    if (rollData) {
+      assets = rollData.assets;
+    }
+
+    return this.rollSkill(skill, rollData, null, assets);
   }
 
   /**

--- a/module/actor/NumeneraPCActor.js
+++ b/module/actor/NumeneraPCActor.js
@@ -189,7 +189,6 @@ export class NumeneraPCActor extends Actor {
       await dialog.init();
       return dialog.render(true);
     }
-    //console.log(dialog);
 
     // Create a pseudo-skill to avoid repeating the roll logic
     //Do NOT create an embedded Document here, we really want a temporary item

--- a/module/apps/EffortDialog.js
+++ b/module/apps/EffortDialog.js
@@ -315,7 +315,7 @@ export class EffortDialog extends FormApplication {
       this.close();
       return;
     }
-      
+
     const data = super.getData();
 
     data.stats = NUMENERA.stats;
@@ -419,6 +419,7 @@ export class EffortDialog extends FormApplication {
     rollData.taskLevel = this.finalLevel;
     rollData.rollMode = this.object.rollMode;
     rollData.damageTrackPenalty = this.object.actor.data.data.damageTrack;
+    rollData.assets = this.object.assets;
 
     if (this.object.skill) {
       let skill = this.object.skill;
@@ -427,7 +428,7 @@ export class EffortDialog extends FormApplication {
       if (skill._id)
         skill = this.object.actor.items.get(this.object.skill.id);
 
-      actor.rollSkill(skill, rollData, this.object.ability);
+      actor.rollSkill(skill, rollData, this.object.ability, this.object.assets);
     }
     else {
       await actor.rollAttribute(shortStat, rollData);


### PR DESCRIPTION
The "Other Enhancements" field of the Effort Dialog is broken. (It has no apparent effect upon use)
It's a feature my group and I would like to use, so I've put together a fix.
I confess, I'm not much for javascript, but I did my best to not be too messy about it. Happy to have any feedback or make any changes. 

I also Changed a couple of field names, `Other Enhancements` I changed to `Assets` to better match the verbiage of the books, 
and I changed the `Cyphers` tab on the character sheet to `Numenera` to better reflect that Artifacts and Oddities live there too.
